### PR TITLE
Add: Wrap the custom component inside `<Link>` with `<a>`

### DIFF
--- a/component/Header.tsx
+++ b/component/Header.tsx
@@ -1,25 +1,27 @@
 import { Box, Flex } from "@chakra-ui/react"
 import Link from 'next/link'
 export function Header(props: HeaderProps) {
-    return (
-      <>
+  return (
+    <>
       <Flex as="nav">
         <Link href={props.url}>
-          <Box 
-            fontWeight="bold" 
-            bg="blue.800" 
-            w="100%" 
-            p={4}
-            pr={6} 
-            color="white" 
-          >
-                tosa.dev
-          </Box>
+          <a>
+            <Box
+              fontWeight="bold"
+              bg="blue.800"
+              w="100%"
+              p={4}
+              pr={6}
+              color="white"
+            >
+              tosa.dev
+            </Box>
+          </a>
         </Link>
       </Flex>
       <Box h="42"></Box>
-      </>
-    );
+    </>
+  );
 }
 
 interface HeaderProps {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import matter from "gray-matter"
 import fs from "fs"
 import { Container, Box, Text, Tag, Flex } from "@chakra-ui/react";
 import Link from 'next/link';
-import {Post, HomePageProps} from "../types/type";
+import { Post, HomePageProps } from "../types/type";
 import { getAllPostsData } from '../utils/getPostsData';
 
 export default function Home(props: HomePageProps) {
@@ -28,10 +28,10 @@ export default function Home(props: HomePageProps) {
           </Box>
           <h3># Posts</h3>
           {props.contents.map(item => {
-              return <PostItem 
-                  {...item}
-                  key={"post-key-" + item.data.slug}
-              />;
+            return <PostItem
+              {...item}
+              key={"post-key-" + item.data.slug}
+            />;
           })}
         </Container>
 
@@ -46,21 +46,23 @@ function PostItem(props: Post) {
   return (
     <Box key={props.data.slug}>
       <Link href={"/posts/" + props.data.slug}>
-        <Container mx="1">
-          <Box>
-            <Text color="gray.300" fontWeight={"normal"} as="span">{props.data.date}</Text>
-          </Box>
-          <Text as="span" fontWeight="bold" _hover={{ color: "#1A0DAB"}}>
-            {props.data.title}
-          </Text>
+        <a>
+          <Container mx="1">
+            <Box>
+              <Text color="gray.300" fontWeight={"normal"} as="span">{props.data.date}</Text>
+            </Box>
+            <Text as="span" fontWeight="bold" _hover={{ color: "#1A0DAB" }}>
+              {props.data.title}
+            </Text>
 
-          {/* <Text>{props.data.description}</Text>
+            {/* <Text>{props.data.description}</Text>
           {props.data.tags != null && props.data.tags.map(item => {
             return <Tag marginRight="1" key={item}>{item}</Tag>
           })} */}
-        </Container>           
+          </Container>
+        </a>
       </Link>
-    </Box>
+    </Box >
   );
 }
 
@@ -72,18 +74,18 @@ export async function getStaticProps() {
     console.log(item.data.slug)
   })
   const tagSet = contents
-                .reduce((acc:Set<string> , val) => {
-                  if (val.data.tags != null) {
-                    const tags = val.data.tags as string[];
-                    tags.forEach(item => acc.add(item));
-                  };
-                  return acc;
-                }, new Set<string>())
+    .reduce((acc: Set<string>, val) => {
+      if (val.data.tags != null) {
+        const tags = val.data.tags as string[];
+        tags.forEach(item => acc.add(item));
+      };
+      return acc;
+    }, new Set<string>())
   const tags = Array.from(tagSet);
   return {
-      props: {
-        contents,
-        tags
-      }
+    props: {
+      contents,
+      tags
+    }
   }
 }

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -1,6 +1,6 @@
 import matter from "gray-matter"
 import fs from "fs"
-import type { PostPageProps, Post } from "../../types/type"
+import type { PostPageProps } from "../../types/type"
 import { GetStaticPropsContext } from 'next'
 import { Container, Box, Heading, Icon, Link } from "@chakra-ui/react"
 import 'highlight.js/styles/github.css';
@@ -12,14 +12,14 @@ export default function PostPage(props: PostPageProps) {
 
   const HeadData = {
     title: props.data.title,
-    url:"https://tosa.dev" + useRouter().asPath,
+    url: "https://tosa.dev" + useRouter().asPath,
     image: "https://tosa.dev/icon.jpeg",
     description: props.data.description
   };
 
   return (
     <div>
-        <BaseHeader {...HeadData} />
+      <BaseHeader {...HeadData} />
       <main>
         <PostView {...props} />
       </main>
@@ -27,7 +27,9 @@ export default function PostPage(props: PostPageProps) {
       <footer>
         <Container height="20">
           <Link href="/">
-            Home...
+            <a>
+              Home...
+            </a>
           </Link>
         </Container>
       </footer>
@@ -36,54 +38,54 @@ export default function PostPage(props: PostPageProps) {
 }
 
 function PostView(props: PostPageProps) {
-    return (
-       <Box w="100vw">
-        <Container padding="4">
-            <Heading as="h2" size="2xl">
-                {props.data.title}
-            </Heading>
-            <Box pt="12">
-                <div dangerouslySetInnerHTML={{ __html: props.content}} />
-            </Box>
-        </Container>
-      </Box>
-    )
+  return (
+    <Box w="100vw">
+      <Container padding="4">
+        <Heading as="h2" size="2xl">
+          {props.data.title}
+        </Heading>
+        <Box pt="12">
+          <div dangerouslySetInnerHTML={{ __html: props.content }} />
+        </Box>
+      </Container>
+    </Box>
+  )
 }
 
 
-const baseName = (str:string) => {
-    const base = new String(str).substring(str.lastIndexOf('/') + 1); 
-     if(base.lastIndexOf(".") != -1) 
-         return base.substring(0, base.lastIndexOf("."));
-    return base;
- }
+const baseName = (str: string) => {
+  const base = new String(str).substring(str.lastIndexOf('/') + 1);
+  if (base.lastIndexOf(".") != -1)
+    return base.substring(0, base.lastIndexOf("."));
+  return base;
+}
 
-export async function getStaticProps(context:GetStaticPropsContext) {
-    if (context.params == null || typeof context.params.id !== "string") return;
-    const path = "./posts/";
-    const file = fs.readFileSync(path + context.params.id + ".md", "utf-8");
-    const content = matter(file);
-    const post = renderMarkdown(content.content);
-    const blogData = {
-        ...content,
-        content: post,
-        orig: "",
-    };
-    return {
-        props: blogData,
-    }
+export async function getStaticProps(context: GetStaticPropsContext) {
+  if (context.params == null || typeof context.params.id !== "string") return;
+  const path = "./posts/";
+  const file = fs.readFileSync(path + context.params.id + ".md", "utf-8");
+  const content = matter(file);
+  const post = renderMarkdown(content.content);
+  const blogData = {
+    ...content,
+    content: post,
+    orig: "",
+  };
+  return {
+    props: blogData,
+  }
 }
 
 export async function getStaticPaths() {
-    const path = "./posts/";
-    const files = fs.readdirSync(path);
-    const paths = files
-        .map(fileName => {
-            return {params: {id: baseName(fileName)}}
-         })
-        .filter(v => v);
-    return {
-        paths: paths,
-        fallback: false
-    }
+  const path = "./posts/";
+  const files = fs.readdirSync(path);
+  const paths = files
+    .map(fileName => {
+      return { params: { id: baseName(fileName) } }
+    })
+    .filter(v => v);
+  return {
+    paths: paths,
+    fallback: false
+  }
 }

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -27,9 +27,7 @@ export default function PostPage(props: PostPageProps) {
       <footer>
         <Container height="20">
           <Link href="/">
-            <a>
-              Home...
-            </a>
+            Home...
           </Link>
         </Container>
       </footer>


### PR DESCRIPTION
If the child of Link is a custom component that wraps an <a> tag, you must add passHref to Link. This is necessary if you’re using libraries like styled-components. Without this, the <a> tag will not have the href attribute, which hurts your site's accessibility and might affect SEO.

https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

（ローカルで lint 走っちゃったごめん）